### PR TITLE
[WEB-3329] Update SDK to support license service endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The tests are run with Pytest and assume that you have your local vagrant machin
 Run the tests with:
 
 ```
-pipenv run pytest
+pipenv run python -m pytest
 ```
 
 This will collect all the tests and run them.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 setuptools.setup(
   name = 'sws-py-sdk',         # How you named your package folder
   packages = ['sws_py_sdk'],   # Choose the same as "name"
-  version = '0.2',      # Start with a small number and increase it with every change you make
+  version = '0.3',      # Start with a small number and increase it with every change you make
   license='MIT',        # Chose a license from here: https://help.github.com/articles/licensing-a-repository
   description = 'A Python SDK for managing communication with SWS APIs',   # Give a short description about your library
   author = 'Benjamin Farrelly',

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,5 @@ setuptools.setup(
     'Programming Language :: Python :: 3.7'
   ],
   python_requires='>=3.6',
+  install_requires=['requests']
 )

--- a/sws_py_sdk/license.py
+++ b/sws_py_sdk/license.py
@@ -36,7 +36,14 @@ class License(Service):
             }
         )
 
-    def create_license_authorization(self, action, app_name, app_version, host_machine_id, host_machine_name, license_id, system_time):
+    def create_license_authorization(self,
+                                     action,
+                                     app_name,
+                                     app_version,
+                                     host_machine_id,
+                                     host_machine_name,
+                                     license_id,
+                                     system_time):
         """
         Create a new license authorization for a host.
 
@@ -55,7 +62,8 @@ class License(Service):
         """
         return self.fetch(
             method='POST',
-            endpoint='/api/v1/me/licenses/authorizations' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations',
+            endpoint='/api/v1/me/licenses/authorizations' if self.sws.user_id == 0
+            else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations',
             auth='bearer',
             headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
             body={
@@ -80,13 +88,20 @@ class License(Service):
         """
         return self.fetch(
             method='POST',
-            endpoint=f'/api/v1/me/licenses/authorizations/{authorization_id}' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations/{authorization_id}',
+            endpoint=f'/api/v1/me/licenses/authorizations/{authorization_id}' if self.sws.user_id == 0
+            else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations/{authorization_id}',
             auth='bearer',
             headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
             body={'status_code': status_code}
         )
 
-    def get_products(self, app_name=None, app_version=None, term=None, show_license_activations=None, include_upgraded=None, include_deleted=None):
+    def get_products(self,
+                     app_name=None,
+                     app_version=None,
+                     term=None,
+                     show_license_activations=None,
+                     include_upgraded=None,
+                     include_deleted=None):
         """
         Gets products owned by the user.
 
@@ -121,14 +136,19 @@ class License(Service):
 
         :param str host_machine_id: Host physical machine id. Required when `product_type_id` is trial product.
         :param int product_type_id: Product type id. One of `product_type_id` or `product_serial_number` is required.
-        :param str product_serial_number: Product serial number. One of `product_type_id` or `product_serial_number` is required.
+        :param str product_serial_number: Product serial number. One of `product_type_id` or `product_serial_number` is
+                                          required.
         :return: Information on product added.
         :rtype: requests.Response
         """
         return self.fetch(
             endpoint='/api/v1/me/products' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/products',
             auth='bearer',
-            body={'host_machine_id': host_machine_id, 'product_type_id': product_type_id, 'product_serial_number': product_serial_number}
+            body={
+                'host_machine_id': host_machine_id,
+                'product_type_id': product_type_id,
+                'product_serial_number': product_serial_number
+            }
         )
 
     def update_product(self, product_id, ilok_user_id):
@@ -141,7 +161,8 @@ class License(Service):
         :rtype: requests.Response
         """
         return self.fetch(
-            endpoint=f'/api/v1/me/products/{product_id}' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/products/{product_id}',
+            endpoint=f'/api/v1/me/products/{product_id}' if self.sws.user_id == 0
+            else f'/api/v1/users/{self.sws.user_id}/products/{product_id}',
             auth='bearer',
             body={'ilok_user_id': ilok_user_id}
         )
@@ -229,11 +250,14 @@ class License(Service):
         """
         Create a new product and it's licenses with the provided purchase reference and customer reference information.
 
-        Only permanent, timelimited and subscription license product types are supported. trial license product types are not supported.
+        Only permanent, timelimited and subscription license product types are supported. trial license product types
+        are not supported.
 
         NOTE 1: One of user_id, user_email_address or reseller_name is required.
-        NOTE 2: When creating a NFR license, `created_by_user_id`, `notes`, `user_id` or `user_email_address` must be specified.
-        NOTE 3: When ordered through Serato Checkout, `checkout_order_id` and `checkout_order_item_id` must be specified.
+        NOTE 2: When creating a NFR license, `created_by_user_id`, `notes`, `user_id` or `user_email_address` must be
+        specified.
+        NOTE 3: When ordered through Serato Checkout, `checkout_order_id` and `checkout_order_item_id` must be
+        specified.
         NOTE 4: When ordered through Magento, `magento_order_id` and `magento_order_item_id` must be specified.
         NOTE 5: requires `app-license-admin` scope.
 
@@ -251,7 +275,8 @@ class License(Service):
         :param int magento_order_id: Magento Order ID.
         :param int magento_order_item_id: Magento Order Item ID.
         :param str subscription_status: Subscription status is required if product is a subscription.
-                                        Valid values are 'Active', 'Canceled', 'Expired', 'Past Due', 'Pending' and 'Expiring'.
+                                        Valid values are 'Active', 'Canceled', 'Expired', 'Past Due', 'Pending' and
+                                        'Expiring'.
         :return: Information on the product added.
         :rtype: requests.Response
         """
@@ -289,8 +314,10 @@ class License(Service):
         Update a product.
 
         NOTE 1: requires `app-license-admin` scope.
-        NOTE 2: When product is ordered through Serato Checkout, `checkout_order_id` and `checkout_order_item_id` must be specified.
-        NOTE 3: When product is ordered through Magento, `magento_order_id` and `mangeto_order_item_id` must be specified.
+        NOTE 2: When product is ordered through Serato Checkout, `checkout_order_id` and `checkout_order_item_id` must
+        be specified.
+        NOTE 3: When product is ordered through Magento, `magento_order_id` and `mangeto_order_item_id` must be
+        specified.
 
         :param str product_id: Product ID to update.
         :param str valid_to: Date at which the licenses associated with the product expire, in ISO 8601 format

--- a/sws_py_sdk/license.py
+++ b/sws_py_sdk/license.py
@@ -1,27 +1,351 @@
-""" This file exposes endpoints from the SWS Identity Service
+""" This file exposes endpoints from the SWS License Service
 """
 
 from requests.auth import HTTPBasicAuth
-
 from sws_py_sdk.service import Service
 
-class License(Service):
 
+class License(Service):
     def __init__(self, sws):
         super().__init__(sws)
         self.service_uri = sws.service_uris['license']
 
-    def get_licenses(self, app_name="", app_version="", term=""):
-        """ Get user's licenses
-            app_name : str
-                Filter by the application that license is for
-            app_version : string
-                Semantic version of application
-            term : str
-                License term: permanent, subscription,  timelimited.
+    def get_licenses(self, app_name=None, app_version=None, term=None, include_upgraded=None, include_deleted=None):
+        """
+        Gets the licenses owned by the user.
+
+        :param str app_name: Use to filter by app name e.g. 'serato_studio'.
+        :param str app_version: Use to filter by app version e.g. "1.9.2"
+        :param str term : Use to filter by term e.g. 'permanent', 'subscription' etc.
+        :param str include_upgraded: If set to 'true', will only return licenses that are upgraded.
+                                     Valid values are 'true' and 'false'.
+        :param str include_deleted: If set to 'true', will only return licenses that are deleted.
+                                    Valid values are 'true' and 'false'. Requires 'user-license-admin' scope.
+        :return: Licenses owned by the user.
+        :rtype: requests.Response
         """
         return self.fetch(
             auth='bearer',
-            endpoint= '/api/v1/me/licenses' if self.sws.user_id == 0 else '/api/v1/users/' + str(self.sws.user_id) + '/licenses',
-            body={'app_name': app_name, 'app_version': app_version, 'term': term}
+            endpoint='/api/v1/me/licenses' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/licenses',
+            body={
+                'app_name': app_name,
+                'app_version': app_version,
+                'term': term,
+                'include_upgraded': include_upgraded,
+                'include_deleted': include_deleted
+            }
+        )
+
+    def create_license_authorization(self, action, app_name, app_version, host_machine_id, host_machine_name, license_id, system_time):
+        """
+        Create a new license authorization for a host.
+
+        :param str action: One of 'activate' or 'deactivate'.
+        :param str app_name: Name of the app to authorize. E.g. 'serato_studio'.
+        :param str app_version: Version of app in format 'major.minor.patch.'.
+        :param str host_machine_id: Machine ID of the host.
+        :param str host_machine_name: Name of host machine.
+        :param str license_id: ID of the license to authorize.
+        :param str system_time: Current Date/time of the client system expressed in ISO 8601 format.
+        :return: a list of all licenses whose current authorization state on the host is activated,
+                 and includes the RLM license file content for each activated license. The list can
+                 be empty in the case that the authorization action is deactivate and no licenses
+                 are authorized on the host
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            method='POST',
+            endpoint='/api/v1/me/licenses/authorizations' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations',
+            auth='bearer',
+            headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+            body={
+                'action': action,
+                'app_name': app_name,
+                'app_version': app_version,
+                'host_machine_id': host_machine_id,
+                'host_machine_name': host_machine_name,
+                'license_id': license_id,
+                'system_time': system_time
+            }
+        )
+
+    def update_license_authorization(self, authorization_id, status_code):
+        """
+        Update the status of a license authorization action.
+
+        :param int authorization_id: The authorization to update.
+        :param int status_code: 0 is success, non-zero values are application specific.
+        :return: HTTP response.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            method='POST',
+            endpoint=f'/api/v1/me/licenses/authorizations/{authorization_id}' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations/{authorization_id}',
+            auth='bearer',
+            headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+            body={'status_code': status_code}
+        )
+
+    def get_products(self, app_name=None, app_version=None, term=None, show_license_activations=None, include_upgraded=None, include_deleted=None):
+        """
+        Gets products owned by the user.
+
+        :param str app_name: Used to filter by app name e.g. "serato_studio".
+        :param str app_version: Used to filter by app version e.g. "1.9.2".
+        :param str term: Used to filter by term. E.g. 'permanent', 'subscription' etc.
+        :param str show_license_activations: Returns activations for licenses if the parameter is set to true.
+                                             Valid values are true or false.
+        :param str include_upgraded: Return all the products include those have the upgrade_to field is not empty
+                                     if the parameter is set to true. Valid values are true or false.
+        :param str include_deleted: Return all the products that are deleted if the parameter is set to true.
+                                    This requires user-license-admin scope. Valid values are true or false.
+        :return: List of products owned by user.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint='/api/v1/me/products' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/products',
+            auth='bearer',
+            body={
+                'app_name': app_name,
+                'app_version': app_version,
+                'term': term,
+                'show_license_activations': show_license_activations,
+                'include_upgraded': include_upgraded,
+                'include_deleted': include_deleted
+            }
+        )
+
+    def add_product(self, host_machine_id=None, product_type_id=None, product_serial_number=None):
+        """
+        Adds a product to the user.
+
+        :param str host_machine_id: Host physical machine id. Required when `product_type_id` is trial product.
+        :param int product_type_id: Product type id. One of `product_type_id` or `product_serial_number` is required.
+        :param str product_serial_number: Product serial number. One of `product_type_id` or `product_serial_number` is required.
+        :return: Information on product added.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint='/api/v1/me/products' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/products',
+            auth='bearer',
+            body={'host_machine_id': host_machine_id, 'product_type_id': product_type_id, 'product_serial_number': product_serial_number}
+        )
+
+    def update_product(self, product_id, ilok_user_id):
+        """
+        Updates a product owned by the user.
+
+        :param str product_id: Id of the product to update.
+        :param str ilok_user_id: iLok user ID.
+        :return: Information on product updated.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint=f'/api/v1/me/products/{product_id}' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/products/{product_id}',
+            auth='bearer',
+            body={'ilok_user_id': ilok_user_id}
+        )
+
+    def get_product_types(self, app_name=None, app_version=None, term=None):
+        """
+        Get a list of software product types.
+
+        :param str app_name: Use to filter by app name e.g. "serato_studio".
+        :param str app_version: Use to filter by app version e.g. "1.9.2".
+        :param str term: Use to filter by license term. E.g. "permanent", "subscription" etc.
+        :return: List of software product types.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint='/api/v1/products/types',
+            auth='bearer',
+            body={'app_name': app_name, 'app_version': app_version, 'term': term }
+        )
+
+    def get_product_type_details(self, product_type_id):
+        """
+        Get detailed product type information including a list of license types delivered by the product type.
+
+        :param int product_type_id: Product type ID to get details for.
+        :return: Detailed information on the product e.g. license types, trial reset dates etc.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint=f'/api/v1/products/types/{product_type_id}',
+            auth='bearer'
+        )
+
+    def reset_trials_for_product_type(self, product_type_id, reset_date):
+        """
+        Reset trials for a product type.
+
+        NOTE: requires `app-license-admin` scope.
+
+        :param int product_type_id: The product ID for the product to reset trials for.
+        :param str reset_date: Trial reset date, expressed as timestamp in ISO 8601 format
+        :return:
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            method='POST',
+            endpoint=f'/api/v1/products/types/{product_type_id}',
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+            body={'reset_date': reset_date}
+        )
+
+    def admin_get_products(self, checkout_order_id=None, magento_order_id=None, user_id=None):
+        """
+        Get a list of products filtered by purchase reference information and/or user ID.
+
+        NOTE: requires `app-license-admin` scope.
+
+        :param int checkout_order_id: Serato checkout order ID.
+        :param int magento_order_id: Magento checkout ID.
+        :param int user_id: User ID.
+        :return: List of products.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint='/api/v1/products/products',
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            body={'checkout_order_id': checkout_order_id, 'magento_order_id': magento_order_id, 'user_id': user_id}
+        )
+
+    def admin_add_product(self,
+                          product_type_id,
+                          user_id=None,
+                          user_email_address=None,
+                          reseller_name=None,
+                          created_by_user_id=None,
+                          nfr=None,
+                          notes=None,
+                          valid_to=None,
+                          checkout_order_id=None,
+                          checkout_order_item_id=None,
+                          magento_order_id=None,
+                          magento_order_item_id=None,
+                          subscription_status=None):
+        """
+        Create a new product and it's licenses with the provided purchase reference and customer reference information.
+
+        Only permanent, timelimited and subscription license product types are supported. trial license product types are not supported.
+
+        NOTE 1: One of user_id, user_email_address or reseller_name is required.
+        NOTE 2: When creating a NFR license, `created_by_user_id`, `notes`, `user_id` or `user_email_address` must be specified.
+        NOTE 3: When ordered through Serato Checkout, `checkout_order_id` and `checkout_order_item_id` must be specified.
+        NOTE 4: When ordered through Magento, `magento_order_id` and `magento_order_item_id` must be specified.
+        NOTE 5: requires `app-license-admin` scope.
+
+        :param int product_type_id: Product type ID.
+        :param int user_id:  User ID to assign to the product.
+        :param str user_email_address: User email to assign to the product when user does not currently have an account.
+        :param str reseller_name: Name of reseller who purchased the products
+        :param str created_by_user_id: Serato created by User ID to assign through an NFR License.
+        :param boolean nfr: Serato NFR state.
+        :param str notes: Serato notes to explain the reason of this NFR License.
+        :param str valid_to: Date at which the licenses associated with the product expire, in ISO 8601 format.
+                             Required when product type is of term subscription
+        :param int checkout_order_id: Serato Checkout Order ID.
+        :param int checkout_order_item_id: Serato Checkout Order Item ID.
+        :param int magento_order_id: Magento Order ID.
+        :param int magento_order_item_id: Magento Order Item ID.
+        :param str subscription_status: Subscription status is required if product is a subscription.
+                                        Valid values are 'Active', 'Canceled', 'Expired', 'Past Due', 'Pending' and 'Expiring'.
+        :return: Information on the product added.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            method='POST',
+            endpoint='/api/v1/products/products',
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+            body={
+                'product_type_id': product_type_id,
+                'user_id': user_id,
+                'user_email_address': user_email_address,
+                'reseller_name': reseller_name,
+                'created_by_user_id': created_by_user_id,
+                'nfr': nfr,
+                'notes': notes,
+                'valid_to': valid_to,
+                'checkout_order_id': checkout_order_id,
+                'checkout_order_item_id': checkout_order_item_id,
+                'magento_order_id': magento_order_id,
+                'magento_order_item_id': magento_order_item_id,
+                'subscription_status': subscription_status
+            }
+        )
+
+    def admin_update_product(self,
+                             product_id,
+                             valid_to=None,
+                             checkout_order_id=None,
+                             checkout_order_item_id=None,
+                             magento_order_id=None,
+                             magento_order_item_id=None,
+                             subscription_status=None):
+        """
+        Update a product.
+
+        NOTE 1: requires `app-license-admin` scope.
+        NOTE 2: When product is ordered through Serato Checkout, `checkout_order_id` and `checkout_order_item_id` must be specified.
+        NOTE 3: When product is ordered through Magento, `magento_order_id` and `mangeto_order_item_id` must be specified.
+
+        :param str product_id: Product ID to update.
+        :param str valid_to: Date at which the licenses associated with the product expire, in ISO 8601 format
+        :param int checkout_order_id: Serato Checkout Order ID.
+        :param int checkout_order_item_id: Serato Checkout Order Item ID.
+        :param int magento_order_id: Magento Order ID.
+        :param int magento_order_item_id: Magento Order Item ID.
+        :param str subscription_status: Subscription status for a subscription product. Valid values are 'Active',
+                                        'Canceled', 'Expired', 'Past Due', 'Pending' and 'Expiring'.
+        :return: Information on product updated.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            method='PUT',
+            endpoint=f'/api/v1/products/products/{product_id}',
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            headers={'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+            body={
+                'valid_to': valid_to,
+                'checkout_order_id': checkout_order_id,
+                'checkout_order_item_id': checkout_order_item_id,
+                'magento_order_id': magento_order_id,
+                'magento_order_item_id': magento_order_item_id,
+                'subscription_status': subscription_status
+            }
+        )
+
+    def delete_product(self, product_id):
+        """
+        Deletes a product.
+
+        NOTE: requires `app-license-admin` scope.
+
+        :param str product_id: Product ID to delete.
+        :return: HTTP response. 204 is successful.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            method='DELETE',
+            endpoint=f'/api/v1/products/products/{product_id}',
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret)
+        )
+
+    def get_product_info(self, product_id):
+        """
+        View product information.
+
+        NOTE: requires `app-license-admin` scope.
+
+        IMPORTANT: Will return information about deleted products.
+        :param str product_id: Product ID view information for.
+        :return: Information on product.
+        :rtype: requests.Response
+        """
+        return self.fetch(
+            endpoint=f'/api/v1/products/products/{product_id}',
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret)
         )

--- a/sws_py_sdk/service.py
+++ b/sws_py_sdk/service.py
@@ -13,7 +13,7 @@ class Service(object):
         self.sws = sws
         self.service_uri = ''
         self.last_request = None
-        self.invalidAccessTokenHandler = None
+        self.invalid_access_token_handler = None
 
     def fetch(self,
     auth,

--- a/sws_py_sdk/service.py
+++ b/sws_py_sdk/service.py
@@ -1,9 +1,8 @@
 """ This is the base class for the Web Service definitions -- includes common functions
 """
 import json
-from requests import Request, HTTPError, Session
+from requests import Request, Session
 from requests.auth import HTTPBasicAuth
-from base64 import b64encode
 
 class Service(object):
     def __init__(self, sws):

--- a/sws_py_sdk/service.py
+++ b/sws_py_sdk/service.py
@@ -76,7 +76,7 @@ class Service(object):
                     # Access token is invalid or expired
                     # 403 2001 - Invalid access token
                     # 401 2002 - Expired access token
-                    return self.invalid_access_token_handler(err)
+                    return self.sws.invalid_access_token_handler(err)
                 else:
                     return err
 

--- a/sws_py_sdk/sws_client.py
+++ b/sws_py_sdk/sws_client.py
@@ -37,10 +37,7 @@ class SwsClient(Sws):
     """ Python does not support inline functions very well
         So the handle function is defined here
     """
-    def handle_invalid_access_token(self, err):
-        # `err.client` is the specific client instance that made the inital request
-        # when the `invalid access token` error was received.
-        client = err.client
+    def handle_invalid_access_token(self, client):
         # Fetch the `last request` object from the service client
         request = client.last_request
 

--- a/tests/integration/ecom_test.py
+++ b/tests/integration/ecom_test.py
@@ -10,111 +10,111 @@ import pytest
 from base_test import me_endpoint_sws_client, user_endpoint_sws_client
 
 def test_get_me_subscriptions(me_endpoint_sws_client):
-    error_response = me_endpoint_sws_client.ecom().get_subscriptions()
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    response = me_endpoint_sws_client.ecom().get_subscriptions()
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_get_user_subscriptions(user_endpoint_sws_client):
-    error_response = user_endpoint_sws_client.ecom().get_subscriptions()
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    response = user_endpoint_sws_client.ecom().get_subscriptions()
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_get_me_subscriptions_with_sub_id(me_endpoint_sws_client):
-    error_response = me_endpoint_sws_client.ecom().get_subscriptions("notasubscriptionid")
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    response = me_endpoint_sws_client.ecom().get_subscriptions("notasubscriptionid")
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_get_user_subscriptions_with_sub_id(user_endpoint_sws_client):
-    error_response = user_endpoint_sws_client.ecom().get_subscriptions("notasubscriptionid")
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    response = user_endpoint_sws_client.ecom().get_subscriptions("notasubscriptionid")
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_update_me_subscription(me_endpoint_sws_client):
     subscription_id="subId"
     number_of_billing_cycle = 400
     payment_method_token = "tokenlookin"
-    error_response = me_endpoint_sws_client.ecom().update_subscription(
+    response = me_endpoint_sws_client.ecom().update_subscription(
         subscription_id=subscription_id,
         number_of_billing_cycle=number_of_billing_cycle,
         payment_method_token=payment_method_token
     )
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_update_user_subscription(user_endpoint_sws_client):
     subscription_id = "bdcbd840933411e9b3ef1239f8b24ea2"
     number_of_billing_cycle = 4
     payment_method_token = "j8d7cx"
-    error_response = user_endpoint_sws_client.ecom().update_subscription(
+    response = user_endpoint_sws_client.ecom().update_subscription(
         subscription_id=subscription_id,
         number_of_billing_cycle=number_of_billing_cycle,
         payment_method_token=payment_method_token
     )
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_delete_me_subscription(me_endpoint_sws_client):
     subscription_id = "subid"
-    error_response = me_endpoint_sws_client.ecom().delete_subscription(subscription_id=subscription_id)
+    response = me_endpoint_sws_client.ecom().delete_subscription(subscription_id=subscription_id)
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_delete_user_subscription(user_endpoint_sws_client):
     subscription_id = "subid"
-    error_response = user_endpoint_sws_client.ecom().delete_subscription(subscription_id=subscription_id)
+    response = user_endpoint_sws_client.ecom().delete_subscription(subscription_id=subscription_id)
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_get_me_orders(me_endpoint_sws_client):
     order_id = 1000
-    error_response = me_endpoint_sws_client.ecom().get_orders(order_id)
+    response = me_endpoint_sws_client.ecom().get_orders(order_id)
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_get_me_orders(user_endpoint_sws_client):
     order_id = 1000
-    error_response = user_endpoint_sws_client.ecom().get_orders(order_id)
+    response = user_endpoint_sws_client.ecom().get_orders(order_id)
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_get_me_invoices(me_endpoint_sws_client):
     order_id = 1000
-    error_response = me_endpoint_sws_client.ecom().get_invoices(order_id)
+    response = me_endpoint_sws_client.ecom().get_invoices(order_id)
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_get_user_invoices(user_endpoint_sws_client):
     order_id = 1000
-    error_response = user_endpoint_sws_client.ecom().get_invoices(order_id)
+    response = user_endpoint_sws_client.ecom().get_invoices(order_id)
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_get_me_payment_methods(me_endpoint_sws_client):
-    error_response = me_endpoint_sws_client.ecom().get_payment_methods()
+    response = me_endpoint_sws_client.ecom().get_payment_methods()
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 405
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 405
+    assert response.status_code != 500
 
 
 def test_get_user_payment_methods(user_endpoint_sws_client):
-    error_response = user_endpoint_sws_client.ecom().get_payment_methods()
+    response = user_endpoint_sws_client.ecom().get_payment_methods()
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_update_me_payment_method(me_endpoint_sws_client):
     payment_token = "Uvuvwevwe"
@@ -122,14 +122,14 @@ def test_update_me_payment_method(me_endpoint_sws_client):
     device_data = "Uvuvwevwes Macbook Pro"
     billing_address_id = "Uv"
 
-    error_response = me_endpoint_sws_client.ecom().update_payment_methods(
+    response = me_endpoint_sws_client.ecom().update_payment_methods(
         payment_token=payment_token,
         nonce=nonce,
         device_data=device_data,
         billing_address_id=billing_address_id
     )
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_update_user_payment_method(user_endpoint_sws_client):
@@ -138,82 +138,82 @@ def test_update_user_payment_method(user_endpoint_sws_client):
     device_data = "Uvuvwevwes Macbook Pro"
     billing_address_id = "Uv"
 
-    error_response = user_endpoint_sws_client.ecom().update_payment_methods(
+    response = user_endpoint_sws_client.ecom().update_payment_methods(
         payment_token=payment_token,
         nonce=nonce,
         device_data=device_data,
         billing_address_id=billing_address_id
     )
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_delete_me_payment_method(me_endpoint_sws_client):
     payment_method_token = "Uvuvwevwe"
-    error_response = me_endpoint_sws_client.ecom().delete_payment_method(payment_method_token=payment_method_token)
+    response = me_endpoint_sws_client.ecom().delete_payment_method(payment_method_token=payment_method_token)
     
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_delete_user_payment_method(user_endpoint_sws_client):
     payment_method_token = "Uvuvwevwe"
-    error_response = user_endpoint_sws_client.ecom().delete_payment_method(payment_method_token=payment_method_token)
+    response = user_endpoint_sws_client.ecom().delete_payment_method(payment_method_token=payment_method_token)
     
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_add_me_plan_change_request(me_endpoint_sws_client):
 
     subscription_id = "Uvuvwevwe"
     catalog_product_id = 105
-    error_response = me_endpoint_sws_client.ecom().add_plan_change_request(
+    response = me_endpoint_sws_client.ecom().add_plan_change_request(
         subscription_id=subscription_id,
         catalog_product_id=catalog_product_id
     )
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_add_user_payment_method(user_endpoint_sws_client):
     nonce = "Uvuvwevwe_Onyetenyevwe_Ugwembubwem_Ossas"
     device_data = "Uvuvwevwes Macbook Pro"
     billing_address_id = "uv"
-    error_response = user_endpoint_sws_client.ecom().add_payment_method(
+    response = user_endpoint_sws_client.ecom().add_payment_method(
         nonce=nonce,
         device_data=device_data,
         billing_address_id=billing_address_id
     )
-    assert error_response.response.status_code != 500
-    assert error_response.response.status_code != 404
+    assert response.status_code != 500
+    assert response.status_code != 404
 
 def test_add_me_payment_method(me_endpoint_sws_client):
     nonce = "Uvuvwevwe_Onyetenyevwe_Ugwembubwem_Ossas"
     device_data = "Uvuvwevwes Macbook Pro"
     billing_address_id = "uv"
-    error_response = me_endpoint_sws_client.ecom().add_payment_method(
+    response = me_endpoint_sws_client.ecom().add_payment_method(
         nonce=nonce,
         device_data=device_data,
         billing_address_id=billing_address_id
     )
-    assert error_response.response.status_code != 500
-    assert error_response.response.status_code != 404
+    assert response.status_code != 500
+    assert response.status_code != 404
 
 def test_update_user_plan_change(user_endpoint_sws_client):
     subscription_id = "subsid"
     plan_change_id = "1000"
-    error_response = user_endpoint_sws_client.ecom().update_plan_change(
+    response = user_endpoint_sws_client.ecom().update_plan_change(
         subscription_id=subscription_id,
         plan_change_id=plan_change_id
     )
-    assert error_response.response.status_code != 500
-    assert error_response.response.status_code != 404
+    assert response.status_code != 500
+    assert response.status_code != 404
 
 
 def test_update_me_plan_change(me_endpoint_sws_client):
     subscription_id = "subsid"
     plan_change_id = "1000"
-    error_response = me_endpoint_sws_client.ecom().update_plan_change(
+    response = me_endpoint_sws_client.ecom().update_plan_change(
         subscription_id=subscription_id,
         plan_change_id=plan_change_id
     )
-    assert error_response.response.status_code != 500
-    assert error_response.response.status_code != 404
+    assert response.status_code != 500
+    assert response.status_code != 404

--- a/tests/integration/identity_test.py
+++ b/tests/integration/identity_test.py
@@ -11,20 +11,20 @@ import json
 from base_test import me_endpoint_sws_client, user_endpoint_sws_client
 
 def test_login(me_endpoint_sws_client):
-    error_response = me_endpoint_sws_client.identity().login(email_address="test.user@serato.com", password="Auckland009")
+    response = me_endpoint_sws_client.identity().login(email_address="test.user@serato.com", password="Auckland009")
 
     assert me_endpoint_sws_client.identity().last_request.data != None
     json_result = json.loads(me_endpoint_sws_client.identity().last_request.data)
     assert json_result['email_address'] == "test.user@serato.com"
     assert json_result['password'] == "Auckland009"
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 def test_create_user(me_endpoint_sws_client):
-    error_response = me_endpoint_sws_client.identity().post_users(
+    response = me_endpoint_sws_client.identity().post_users(
         email_address="test.useruser@serato.com",
         password="test_password"
     )
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500

--- a/tests/integration/identity_test.py
+++ b/tests/integration/identity_test.py
@@ -20,28 +20,30 @@ def test_login(me_endpoint_sws_client):
     assert response.status_code != 404
     assert response.status_code != 500
 
+
 def test_create_user(me_endpoint_sws_client):
     response = me_endpoint_sws_client.identity().post_users(
         email_address="test.useruser@serato.com",
         password="test_password"
     )
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
+
 
 def test_me_groups(me_endpoint_sws_client):
-    error_response = me_endpoint_sws_client.identity().post_groups(
+    response = me_endpoint_sws_client.identity().post_groups(
         group_name="serato"
     )
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500
 
 
 def test_user_groups(user_endpoint_sws_client):
-    error_response = user_endpoint_sws_client.identity().post_groups(
+    response = user_endpoint_sws_client.identity().post_groups(
         group_name="serato"
     )
 
-    assert error_response.response.status_code != 404
-    assert error_response.response.status_code != 500
+    assert response.status_code != 404
+    assert response.status_code != 500

--- a/tests/integration/license_test.py
+++ b/tests/integration/license_test.py
@@ -1,0 +1,180 @@
+""" The purpose of this test file is to perform basic integration tests 
+
+    The scope of these tests only includes checking that non-404 responses can be attained.
+    Testing that endpoints actually work to spec is the responsibility of the API and Client.
+"""
+
+from base_test import me_endpoint_sws_client as me_client, user_endpoint_sws_client as user_client
+
+
+def test_get_me_licenses(me_client):
+    response = me_client.license().get_licenses()
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_get_user_licenses(user_client):
+    response = user_client.license().get_licenses()
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_create_me_license_authorization(me_client):
+    action = 'activate'
+    app_name = 'serato_studio'
+    app_version = '1.0.0'
+    host_machine_id = 'ABC123123'
+    host_machine_name = 'My Machine'
+    license_id = '420'
+    system_time = '2019-10-10T17:01:33+13:00'
+    response = me_client.license().create_license_authorization(action=action,
+                                                                app_name=app_name,
+                                                                app_version=app_version,
+                                                                host_machine_id=host_machine_id,
+                                                                host_machine_name=host_machine_name,
+                                                                license_id=license_id,
+                                                                system_time=system_time)
+
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_create_user_license_authorization(user_client):
+    action = 'activate'
+    app_name = 'serato_studio'
+    app_version = '1.0.0'
+    host_machine_id = 'ABC123123'
+    host_machine_name = 'My Machine'
+    license_id = '420'
+    system_time = '2019-10-10T17:01:33+13:00'
+    response = user_client.license().create_license_authorization(action=action,
+                                                                  app_name=app_name,
+                                                                  app_version=app_version,
+                                                                  host_machine_id=host_machine_id,
+                                                                  host_machine_name=host_machine_name,
+                                                                  license_id=license_id,
+                                                                  system_time=system_time)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_update_me_license_authorization(me_client):
+    authorization_id = 420
+    authorization_status_code = 111
+    response = me_client.license().update_license_authorization(authorization_id, authorization_status_code)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_update_user_license_authorization(user_client):
+    authorization_id = 420
+    authorization_status_code = 111
+    response = user_client.license().update_license_authorization(authorization_id, authorization_status_code)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_get_me_products(me_client):
+    response = me_client.license().get_products()
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_get_user_products(user_client):
+    response = user_client.license().get_products()
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_add_me_product(me_client):
+    product_type_id = 420
+    response = me_client.license().add_product(product_type_id=product_type_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_add_user_product(user_client):
+    product_type_id = 420
+    response = user_client.license().add_product(product_type_id=product_type_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_update_me_product(me_client):
+    product_id = '420'
+    ilok_user_id = '42'
+    response = me_client.license().update_product(product_id=product_id, ilok_user_id=ilok_user_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_update_me_product(user_client):
+    product_id = '420'
+    ilok_user_id = '42'
+    response = user_client.license().update_product(product_id=product_id, ilok_user_id=ilok_user_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_get_product_types(me_client):
+    response = me_client.license().get_product_types()
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_get_product_type_details(me_client):
+    product_type_id = 420
+    response = me_client.license().get_product_type_details(product_type_id=product_type_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_reset_trials_for_product_type(me_client):
+    product_type_id = 420
+    reset_date = '2019-10-10T17:01:33+13:00'
+    response = me_client.license().reset_trials_for_product_type(product_type_id=product_type_id, reset_date=reset_date)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_admin_get_products(me_client):
+    checkout_order_id = 420
+    response = me_client.license().admin_get_products(checkout_order_id=checkout_order_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_admin_add_product(me_client):
+    product_type_id = 420
+    created_by_user_id = '111'
+    user_email_address = 'lollies@lollyjar.com'
+    nfr = 'true'
+    notes = 'I want this person to have a NFR.'
+    response = me_client.license().admin_add_product(product_type_id=product_type_id,
+                                                     user_email_address=user_email_address,
+                                                     created_by_user_id=created_by_user_id,
+                                                     nfr=nfr,
+                                                     notes=notes)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_admin_update_product(me_client):
+    product_id = 420
+    response = me_client.license().admin_update_product(product_id=product_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_delete_product(me_client):
+    product_id = 420
+    response = me_client.license().delete_product(product_id=product_id)
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+
+def test_get_product_info(me_client):
+    product_id = 420
+    response = me_client.license().get_product_info(product_id=product_id)
+    assert response.status_code != 404
+    assert response.status_code != 500

--- a/tests/spec/sws_client_test.py
+++ b/tests/spec/sws_client_test.py
@@ -131,7 +131,7 @@ MOCK_GET_LICENSES_RESPONSE_BODY = {
 }
 
 TOKEN_REFRESH_URL = '/api/v1/me/tokens/refresh'
-GET_LICENSES_API = '/api/v1/users/1000/licenses?app_name=&app_version=&term='
+GET_LICENSES_API = '/api/v1/users/1000/licenses'
 SERVICE_URI = {
     "id": "http://192.168.4.7",
     "license": "http://192.168.4.6"


### PR DESCRIPTION
Setting the pull request to be WEB-3329 -> WEB-3327 at the moment, until WEB-3329 has been merged into master. Will change the base to master once this has happened.

This PR has breaking changes, namely `Service.fetch_request` has changed behaviour meaning that it will always return a `requests.Response` object, rather than the current behaviour where it can return `requests.Response` or `requests.HTTPError`. The tests in the SDK on this branch have been updated to reflect this.