### PR TITLE
[WEB-3329] Fix broken functions for license API

### DIFF
--- a/sws_py_sdk/license.py
+++ b/sws_py_sdk/license.py
@@ -87,7 +87,7 @@ class License(Service):
         :rtype: requests.Response
         """
         return self.fetch(
-            method='POST',
+            method='PUT',
             endpoint=f'/api/v1/me/licenses/authorizations/{authorization_id}' if self.sws.user_id == 0
             else f'/api/v1/users/{self.sws.user_id}/licenses/authorizations/{authorization_id}',
             auth='bearer',
@@ -142,6 +142,7 @@ class License(Service):
         :rtype: requests.Response
         """
         return self.fetch(
+            method='POST',
             endpoint='/api/v1/me/products' if self.sws.user_id == 0 else f'/api/v1/users/{self.sws.user_id}/products',
             auth='bearer',
             body={
@@ -161,6 +162,7 @@ class License(Service):
         :rtype: requests.Response
         """
         return self.fetch(
+            method='PUT',
             endpoint=f'/api/v1/me/products/{product_id}' if self.sws.user_id == 0
             else f'/api/v1/users/{self.sws.user_id}/products/{product_id}',
             auth='bearer',

--- a/sws_py_sdk/service.py
+++ b/sws_py_sdk/service.py
@@ -104,7 +104,10 @@ class Service(object):
             request.params = body
 
         if method == 'PUT' or method == 'PATCH' or method == 'POST':
-            request.data = json.dumps(body)
+            if 'Content-Type' in headers and headers['Content-Type'] is 'application/x-www-form-urlencoded':
+                request.data = body
+            else:
+                request.data = json.dumps(body)  # JSON in the body by default
             if params != {}:
                 request.params = params
         return request

--- a/sws_py_sdk/service.py
+++ b/sws_py_sdk/service.py
@@ -104,7 +104,7 @@ class Service(object):
             request.params = body
 
         if method == 'PUT' or method == 'PATCH' or method == 'POST':
-            if 'Content-Type' in headers and headers['Content-Type'] is 'application/x-www-form-urlencoded':
+            if 'Content-Type' in headers and headers['Content-Type'] == 'application/x-www-form-urlencoded':
                 request.data = body
             else:
                 request.data = json.dumps(body)  # JSON in the body by default


### PR DESCRIPTION
Two issues were picked up:

1) Some functions had the incorrect methods for the endpoints.

2) Requests with `Content-Type` of `application/x-www-form-urlencoded` were not being encoded correctly, all POST requests had their data encoded in JSON indiscriminately.