### PR TITLE
[WEB-3584] Add mssing endpoint based on serato website

### DIFF
--- a/sws_py_sdk/identity.py
+++ b/sws_py_sdk/identity.py
@@ -24,6 +24,27 @@ class Identity(Service):
             method='POST'
         )
 
+    def token_exchange(self, grant_type, code, redirect_uri):
+        """ POST exchange an authorization code for access and refresh tokens via /tokens/exchange endpoint
+            grant_type : str
+                authorization_code
+            code : str
+                Authorization code
+            redirect_uri : str
+                The redirect URI supplied when the authorization code was issued
+        """
+        endpoint = '/tokens/exchange'
+        return self.fetch(
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            endpoint=endpoint,
+            body={
+                'grant_type': grant_type,
+                'code': code,
+                'redirect_uri': redirect_uri
+            },
+            method='POST'
+        )
+
     def login(self, email_address, password, device_id='', device_name=''):
         """ Logs user in with Basic auth
             email_address : str
@@ -47,6 +68,23 @@ class Identity(Service):
             method='POST'
         )
 
+    def logout(self, refresh_token='', refresh_token_ids=''):
+        """ Logs user out via /me/logout endpoint
+            refresh_token : string
+                Refresh token for user that proves they deserve a new access token.
+            refresh_token_ids : string
+                A comma separated list of refresh token IDs.
+        """
+        endpoint = '/api/v1/me' if self.sws.user_id == 0 else '/api/v1/users/' + str(self.sws.user_id)
+        endpoint += '/logout'
+        return self.fetch(
+            auth='bearer',
+            endpoint=endpoint,
+            body={ "refresh_token": refresh_token, "refresh_token_ids": refresh_token_ids },
+            method='POST',
+        )
+
+    
     def post_users(self, email_address, password, first_name=None, last_name=None, locale=None):
         """ Creates user via the /users endpoint
             email_address : str
@@ -78,6 +116,7 @@ class Identity(Service):
             },
             method='POST'
         )
+
     def post_groups(self, group_name):
         """ Adds the authenticated client user to a user group
             group_name : str
@@ -92,4 +131,94 @@ class Identity(Service):
                 "group_name": group_name
             },
             method='POST'
+        )
+
+    def get_user(self):
+        """ Get user detail via /api/v1/me, /api/v1/users/{user_id} endpoint
+        """
+        endpoint = '/api/v1/me' if self.sws.user_id == 0 else '/api/v1/users/'+ str(self.sws.user_id)
+        return self.fetch(
+            auth='bearer',
+            endpoint=endpoint,
+            body={},
+            method='GET'
+        )
+
+    def get_users(self, email_address='', ga_client_id='', app_session_cookie=''):
+        """ Get list of users via /api/v1/users endpoint
+            email_address : str
+                User's email address
+            ga_client_id : str
+                Google Client ID
+            app_session_cookie : str    
+                application session cookie value        
+        """
+        endpoint = '/users'
+        return self.fetch(
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            endpoint=endpoint,
+            body={
+                'email_address': email_address
+            },
+            method='GET'
+        )
+
+    def delete_user(self):
+        """ DELETE  create user deactivation request.
+        """
+        endpoint = '/api/v1/me' 
+        return self.fetch(
+            auth='bearer',
+            endpoint=endpoint,
+            body={},
+            method='DELETE'
+        )
+
+    def reset_password(self, email_address):
+        """ POST reset user password via /sendresetpassword endpoint
+            email_address : str
+                User's email address
+        """
+        endpoint = '/api/v1/sendresetpassword'
+        return self.fetch(
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            endpoint=endpoint,
+            body={
+                'email_address': email_address
+            },
+            method='POST'
+        )
+
+    def verify_email_address(self, email_address, redirect_uri):
+        """ Post send an email to verify a change in this user's email address
+            email_address : str
+                User's email address
+            redirect_uri : str
+                URI to redirect to after an email is sent
+        """
+        endpoint = '/api/v1/me' if self.sws.user_id == 0 else '/api/v1/users/'+ str(self.sws.user_id)
+        endpoint += '/sendverifyemailaddress'
+        return self.fetch(
+            auth='bearer',
+            endpoint=endpoint,
+            body={
+                'email_address': email_address,
+                'redirect_uri': redirect_uri
+            },
+            method:'POST'
+        )
+
+    def post_user_gaclientid(self, ga_client_id):
+        """ POST add a Google Client ID association to a user
+            ga_client_id : str
+                Google Client ID
+        """
+        endpoint = '/api/v1/users/'+ str(self.sws.user_id) + '/gaclientid'
+        return self.fetch(
+            auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
+            endpoint=endpoint,
+            body={
+                'ga_client_id': ga_client_id
+            },
+            method:'POST'
         )

--- a/sws_py_sdk/identity.py
+++ b/sws_py_sdk/identity.py
@@ -19,7 +19,7 @@ class Identity(Service):
         """
         return self.fetch(
             auth=None,
-            endpoint='/api/v1/me/tokens/refresh',
+            endpoint='/api/v1/tokens/refresh',
             body={'refresh_token': refresh_token},
             method='POST'
         )
@@ -33,7 +33,7 @@ class Identity(Service):
             redirect_uri : str
                 The redirect URI supplied when the authorization code was issued
         """
-        endpoint = '/tokens/exchange'
+        endpoint = '/api/v1/tokens/exchange'
         return self.fetch(
             auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
             endpoint=endpoint,
@@ -153,7 +153,7 @@ class Identity(Service):
             app_session_cookie : str    
                 application session cookie value        
         """
-        endpoint = '/users'
+        endpoint = '/api/v1/users'
         return self.fetch(
             auth=HTTPBasicAuth(username=self.sws.app_id, password=self.sws.secret),
             endpoint=endpoint,
@@ -190,7 +190,8 @@ class Identity(Service):
         )
 
     def verify_email_address(self, email_address, redirect_uri):
-        """ Post send an email to verify a change in this user's email address
+        """ Post send an email to verify a change in this user's email address 
+            via /me/sendverifyemailaddress, /users/{user_id}/sendverifyemailaddress
             email_address : str
                 User's email address
             redirect_uri : str
@@ -205,7 +206,7 @@ class Identity(Service):
                 'email_address': email_address,
                 'redirect_uri': redirect_uri
             },
-            method:'POST'
+            method='POST'
         )
 
     def post_user_gaclientid(self, ga_client_id):
@@ -220,5 +221,5 @@ class Identity(Service):
             body={
                 'ga_client_id': ga_client_id
             },
-            method:'POST'
+            method='POST'
         )

--- a/tests/integration/identity_test.py
+++ b/tests/integration/identity_test.py
@@ -12,7 +12,7 @@ from base_test import me_endpoint_sws_client, user_endpoint_sws_client
 
 def test_login(me_endpoint_sws_client):
     response = me_endpoint_sws_client.identity().login(email_address="test.user@serato.com", password="Auckland009")
-
+    
     assert me_endpoint_sws_client.identity().last_request.data != None
     json_result = json.loads(me_endpoint_sws_client.identity().last_request.data)
     assert json_result['email_address'] == "test.user@serato.com"
@@ -45,5 +45,91 @@ def test_user_groups(user_endpoint_sws_client):
         group_name="serato"
     )
 
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+def test_me_logout(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().logout(refresh_token="serato")
+    
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+def test_user_logout(user_endpoint_sws_client):
+    response = user_endpoint_sws_client.identity().logout(refresh_token="serato")
+    
+    assert response.status_code != 404
+    assert response.status_code != 500
+
+def test_token_refresh(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().token_refresh(refresh_token="serato")
+    
+    assert response.status_code != 404
+    assert response.status_code != 500 
+
+def test_token_exchange(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().token_exchange(
+        grant_type="grant_type",
+        code="code",
+        redirect_uri="redirect_uri"
+    )
+    
+    assert response.status_code != 404
+    assert response.status_code != 500    
+
+def test_get_users(user_endpoint_sws_client):
+    response = user_endpoint_sws_client.identity().get_users(email_address="test@serato.com")
+    
+    assert response.status_code != 404
+    assert response.status_code != 500  
+
+def test_get_me(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().get_user()
+    
+    assert response.status_code != 404
+    assert response.status_code != 500  
+
+def test_get_me(user_endpoint_sws_client):
+    response = user_endpoint_sws_client.identity().get_user()
+    
+    assert response.status_code != 404
+    assert response.status_code != 500  
+
+def test_delete_me(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().delete_user()
+    
+    assert response.status_code != 404
+    assert response.status_code != 500  
+
+def test_reset_password(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().reset_password(
+        email_address="test@serato.com"
+    )
+    
+    assert response.status_code != 404
+    assert response.status_code != 500 
+
+def test_me_verify_email_address(me_endpoint_sws_client):
+    response = me_endpoint_sws_client.identity().verify_email_address(
+        email_address="test@serato.com", 
+        redirect_uri="https://serato.com"
+    )
+    
+    assert response.status_code != 404
+    assert response.status_code != 500 
+
+def test_me_verify_email_address(user_endpoint_sws_client):
+    response = user_endpoint_sws_client.identity().verify_email_address(
+        email_address="test@serato.com", 
+        redirect_uri="https://serato.com"
+    )
+    
+    assert response.status_code != 404
+    assert response.status_code != 500 
+
+def test_post_user_gaclientid(user_endpoint_sws_client):
+    response = user_endpoint_sws_client.identity().post_user_gaclientid(
+        ga_client_id="ga_client_id"
+    )
+    
     assert response.status_code != 404
     assert response.status_code != 500

--- a/tests/integration/identity_test.py
+++ b/tests/integration/identity_test.py
@@ -88,7 +88,7 @@ def test_get_me(me_endpoint_sws_client):
     assert response.status_code != 404
     assert response.status_code != 500  
 
-def test_get_me(user_endpoint_sws_client):
+def test_get_user(user_endpoint_sws_client):
     response = user_endpoint_sws_client.identity().get_user()
     
     assert response.status_code != 404


### PR DESCRIPTION
Add missing endpoint
 - token_exchange : /token/exchange POST
 - logout : /logout POST
 - get_user : /me, /users/{user_id} GET
 - get_users: /users GET
 - delete_user: /me DELETE
 - reset_password: /sendresetpassword POST
 - verify_email_address: /me/sendverifyemailaddress, /users/{user_id}/sendverifyemailaddress POST
 - post_user_gaclientid: /users/{user_id}/gaclientid POST