### PR TITLE
[TDO-372] Add test stack CDN authentication header to SDK requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 setuptools.setup(
   name = 'sws-py-sdk',         # How you named your package folder
   packages = ['sws_py_sdk'],   # Choose the same as "name"
-  version = '0.10.1',      # Start with a small number and increase it with every change you make
+  version = '0.10.2',      # Start with a small number and increase it with every change you make
   license='MIT',        # Chose a license from here: https://help.github.com/articles/licensing-a-repository
   description = 'A Python SDK for managing communication with SWS APIs',   # Give a short description about your library
   author = 'Benjamin Farrelly',

--- a/sws_py_sdk/service.py
+++ b/sws_py_sdk/service.py
@@ -109,6 +109,10 @@ class Service(object):
         if self.sws.test_env:
             request.headers.update(self.FirewallHeader.getHeader())
 
+        # If test stack CDN credentials were provided, add the x-serato-cdn-auth header to the request
+        if self.sws.cdn_auth_id and self.sws.cdn_auth_secret:
+            request.headers.update(self.sws.get_cdn_auth_header())
+
         if method == 'PUT' or method == 'PATCH' or method == 'POST':
             if 'Content-Type' in headers and headers['Content-Type'] == 'application/x-www-form-urlencoded':
                 request.data = body

--- a/sws_py_sdk/sws.py
+++ b/sws_py_sdk/sws.py
@@ -3,6 +3,8 @@
     Encapsulates the functionality required to communicate with the endpoints we provide.
     The definitions of each service will be contained in separate classes
 """
+import base64
+
 from sws_py_sdk import identity, license, ecom
 
 service_uri_default = {
@@ -23,7 +25,9 @@ class Sws(object):
         timeout=3000,
         service_uri={},
         invalid_access_token_handler=None,
-        test_env=False
+        test_env=False,
+        cdn_auth_id=None,
+        cdn_auth_secret=None,
     ):
         """
         Create SWS object
@@ -45,6 +49,10 @@ class Sws(object):
             Base URI for SWS License Service
         auto_refresh : boolean
             Determines if the client will attempt to refresh the access token if invalid or expired.
+        cdn_auth_id : str
+            Client ID used to authenticate with test stack CDNs
+        cdn_auth_secret : str
+            Secret used to authenticate with test stack CDNs
         """
         self.app_id = app_id
         self.secret = secret
@@ -66,6 +74,8 @@ class Sws(object):
         }
         self.invalid_access_token_handler = invalid_access_token_handler
         self.test_env = test_env
+        self.cdn_auth_id = cdn_auth_id
+        self.cdn_auth_secret = cdn_auth_secret
 
     def identity(self):
         """ Getter for the id service instance """
@@ -78,3 +88,10 @@ class Sws(object):
     def ecom(self):
         """ Getter for the ecom service instance """
         return self.service['ecom']
+
+    def get_cdn_auth_header(self):
+        """ Returns the x-serato-cdn-auth header, encoding the credentials used to access test stack CDNs
+        """
+        credentials = f'{self.cdn_auth_id}:{self.cdn_auth_secret}'
+        encoded_credentials = base64.b64encode(credentials.encode('ascii')).decode('ascii')
+        return {'x-serato-cdn-auth': encoded_credentials}

--- a/sws_py_sdk/sws_client.py
+++ b/sws_py_sdk/sws_client.py
@@ -8,7 +8,8 @@ from .sws import Sws
 
 class SwsClient(Sws):
 
-    def __init__(self, app_id, secret=None, user_id=0, timeout=3000, service_uri={}, auto_refresh=True, test_env=False):
+    def __init__(self, app_id, secret=None, user_id=0, timeout=3000, service_uri={}, auto_refresh=True, test_env=False,
+                 cdn_auth_id=None, cdn_auth_secret=None):
         """
         Here we set up a mechanism for token refresh to be handled and triggered
         Create SWS object
@@ -32,9 +33,14 @@ class SwsClient(Sws):
             Determines if the client will attempt to refresh the access token if invalid or expired.
         test_env : boolean
             Determines if we want to run the unitest from travis.
+        cdn_auth_id : str
+            Client ID used to authenticate with test stack CDNs
+        cdn_auth_secret : str
+            Secret used to authenticate with test stack CDNs
         """
         super().__init__(app_id=app_id, secret=secret, user_id=user_id, timeout=timeout, service_uri=service_uri,
-                         invalid_access_token_handler=self._handle_invalid_access_token, test_env=test_env)
+                         invalid_access_token_handler=self._handle_invalid_access_token, test_env=test_env,
+                         cdn_auth_id=cdn_auth_id, cdn_auth_secret=cdn_auth_secret)
         self.auto_refresh = auto_refresh
         self.access_token_updated_callback = None
 

--- a/tests/spec/service_test.py
+++ b/tests/spec/service_test.py
@@ -47,3 +47,15 @@ def test_token_refresh_returns_tokens(requests_mock):
     assert json_response['user']['id'] == 12345
     assert json_response['tokens']['access']['token'] == "NgCXRKdjsLksdKKJjslPQmxMzYjw"
     assert json_response['tokens']['refresh']['token'] == "NgAagAAYqJQjdkEkjkjSkkseKSKaweplOeklUm_SHo"
+
+
+def test_cdn_auth_header(requests_mock):
+    """Tests that the test stack CDN authentication header is added to requests, if credentials are given"""
+    sws = Sws(app_id=app_id, secret='myclientapppassword', service_uri=SERVICE_URI, cdn_auth_id='test_id',
+              cdn_auth_secret='test_secret')
+    url = SERVICE_URI['id'] + TOKEN_REFRESH_URL
+    requests_mock.register_uri('POST', url, json=MOCK_RESPONSE_BODY,
+                               request_headers={'x-serato-cdn-auth': 'dGVzdF9pZDp0ZXN0X3NlY3JldA=='})
+
+    # Any API call (validating the request headers)
+    sws.identity().token_refresh(refresh_token='totally_refresh_refresh_token')

--- a/tests/spec/sws_test.py
+++ b/tests/spec/sws_test.py
@@ -1,3 +1,5 @@
+import base64
+
 from sws_py_sdk.sws import Sws
 from sws_py_sdk.identity import Identity
 import pytest
@@ -18,3 +20,12 @@ def test_init_sws_with_client_data():
     client = Sws(app_id=app_id, secret='myclientapppassword', service_uri=SERVICE_URI)
     assert client.app_id == app_id
     assert client.secret == 'myclientapppassword'
+
+
+def test_cdn_auth_credentials():
+    """Check that the SWS object is able to construct a valid test stack CDN header"""
+    client = Sws(app_id=app_id, secret='myclientapppassword', service_uri=SERVICE_URI, cdn_auth_id='test_id',
+                 cdn_auth_secret='test_secret')
+    cdn_header = client.get_cdn_auth_header()
+    assert 'x-serato-cdn-auth' in cdn_header
+    assert base64.b64decode(cdn_header['x-serato-cdn-auth']).decode('ascii') == 'test_id:test_secret'


### PR DESCRIPTION
https://serato.atlassian.net/browse/TDO-372

Allow requests from the SWS Python SDK to test stack CDNs. Requests without a special header (or from a trusted IP) are otherwise blocked by a CloudFront edge function.

- Add a custom `x-serato-cdn-auth` header to all requests. This header's value should be the base-64-encoded credentials for the test automation client. Unencoded, this looks like `username:password` (similar to basic auth)
- Add CDN auth ID and secret as optional arguments to the SWS SDK (and `SwsClient`)